### PR TITLE
use Replicate Lifeboat to support Llama 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ npx yolox@latest "use ffmpeg to convert foo.mkv to foo.mp4"
 
 ## Usage
 
-This thing only supports OpenAI GPT for the moment, but it could be easily updated to support other models using Replicate, Ollama, etc. [Pull requests welcome!](https://github.com/zeke/yolox/issues)
+yolox supports [GPT4o](https://openai.com/index/hello-gpt-4o/) on OpenAI and [Llama 3](https://replicate.com/meta/meta-llama-3-70b-instruct) on Replicate.
+
+To add support for other models or providers, [open a pull request](https://github.com/zeke/yolox/issues)!
+
+### OpenAI Usage (GPT4o)
 
 Set your OpenAI API key in the environment:
 
@@ -55,13 +59,28 @@ Set your OpenAI API key in the environment:
 export OPENAI_API_KEY="..."
 ```
 
-Give it a command and it will execute it:
+Then give it a command and it will execute it:
 
 ```
-yolox extract audio from maths.mp4 and save it as maths.m4a
-# shell command to extract audio from maths.mp4 and save it as maths.m4a
+yolox "extract audio from maths.mp4 and save it as maths.m4a"
 # ffmpeg -i maths.mp4 -vn -acodec copy maths.m4a
 ```
+
+### Replicate Usage (Llama 3)
+
+Set your Replicate token in the environment:
+
+```console
+export REPLICATE_API_TOKEN="r8_..."
+```
+
+Then specify `model` as a flag set to `llama` or `llama3`:
+
+```
+yolox "extract audio from maths.mp4 and save it as maths.m4a" --model=llama3
+# ffmpeg -i maths.mp4 -vn -acodec copy maths.m4a
+```
+
 
 ## Alternatives
 

--- a/client.js
+++ b/client.js
@@ -1,0 +1,32 @@
+import OpenAI from 'openai'
+
+export function createClient (provider) {
+  let client
+  switch (provider) {
+    case 'openai':
+      client = new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY
+      })
+
+      client.completionOptions = {
+        stream: true
+      }
+
+      break
+    case 'replicate':
+      client = new OpenAI({
+        apiKey: process.env.REPLICATE_API_TOKEN,
+        baseURL: 'https://openai-proxy.replicate.com/v1'
+      })
+
+      // Lifeboat and OpenAI have slight differences...
+      client.completionOptions = {
+        maxTokens: 64,
+        stream: true
+      }
+
+      break
+  }
+
+  return client
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
+        "minimist": "^1.2.8",
         "openai": "^4.50.0"
       },
       "bin": {
@@ -2552,7 +2553,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "author": "Zeke Sikelianos <zeke@sikelianos.com> (http://zeke.sikelianos.com/)",
   "license": "MIT",
   "dependencies": {
+    "minimist": "^1.2.8",
     "openai": "^4.50.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,20 @@
+import OpenAI from 'openai'
+
+const openai = new OpenAI({
+  apiKey: process.env.REPLICATE_API_TOKEN,
+  baseURL: 'https://openai-proxy.replicate.com/v1'
+})
+
+const completions = await openai.chat.completions.create({
+  model: 'meta/meta-llama-3-70b-instruct',
+  messages: [
+    {
+      role: 'user',
+      content: 'Write a haiku about camelids'
+    }
+  ],
+  maxTokens: 64
+})
+for await (const part of completions) {
+  process.stdout.write(part.choices[0]?.delta?.content || '')
+}


### PR DESCRIPTION
This PR updates yolox to support using Llama3 on Replicate as an alternative to GPT on OpenAI.

```
yolox "extract audio from maths.mp4 and save it as maths.m4a" --model=llama3
```

WIP: Blocked by some issues with Lifeboat.