### PR TITLE
feat: add stdin support for piped data input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,35 @@ $ yolox "add 100px white padding around dots.png and save it as dots-with-room.p
 # convert dots.png -bordercolor white -border 100 dots-with-room.png
 ```
 
+### Working with Piped Data
+
+You can pipe data to yolox and it will include that data in the context when generating commands:
+
+```bash
+$ echo '{"name": "Alice", "age": 30, "city": "NYC"}' | yolox "use jq to extract just the name"
+# echo '{"name": "Alice", "age": 30, "city": "NYC"}' | jq '.name'
+```
+
+```bash
+$ cat users.json | yolox "use jq to get all users over age 25"
+# cat users.json | jq '.[] | select(.age > 25)'
+```
+
+```bash
+$ ps aux | yolox "find processes using more than 50% CPU"
+# ps aux | awk '$3 > 50'
+```
+
+```bash
+$ curl -s https://api.github.com/users/octocat | yolox "extract the public repos count with jq"
+# curl -s https://api.github.com/users/octocat | jq '.public_repos'
+```
+
+### File-based Prompts
+
 You can also pass a file containing the prompt. This lets you write long prompts and iterate on them without retyping:
 
-```
+```bash
 echo "do some stuff" > PROMPT.md
 $ yolox PROMPT.md
 ```
@@ -54,8 +80,37 @@ npx yolox@latest "use ffmpeg to convert foo.mkv to foo.mp4"
 
 ## Usage
 
-```
-yolox <prompt-string-or-filename-containing-prompt-string>
+yolox supports three input methods:
+
+1. **Direct command**: `yolox "command description"`
+2. **File input**: `yolox filename.txt` (where the file contains the command description)
+3. **Stdin input**: `echo "data" | yolox "process this data"`
+
+### Command Line Options
+
+- `--model`: Choose the AI model to use (default: `gpt-4o`)
+  - `gpt-4o` or `gpt4`: Uses OpenAI's GPT-4o
+  - `llama`, `llama3`, or `llama31`: Uses Meta's Llama models on Replicate
+- `--print`: Show the generated command without executing it
+
+### Examples
+
+```bash
+# Basic usage
+yolox "list files by size"
+
+# Use specific model
+yolox --model=llama "compress all png files"
+
+# Print mode (don't execute)
+yolox --print "find large files"
+
+# With piped data
+cat data.csv | yolox "convert to JSON using any available tools"
+
+# Using a prompt file
+echo "complex multi-line prompt here" > prompt.txt
+yolox prompt.txt
 ```
 
 yolox supports [GPT4o](https://openai.com/index/hello-gpt-4o/) on OpenAI and [Llama 3](https://replicate.com/meta/meta-llama-3-70b-instruct) on Replicate.
@@ -100,6 +155,22 @@ Print the command but don't execute it:
 yolox --print "extract audio from maths.mp4 and save it as maths.m4a"
 ffmpeg -i maths.mp4 -vn -acodec copy maths.m4a
 ```
+
+## Testing
+
+Run the test suite:
+
+```console
+npm test
+```
+
+The tests cover:
+- Basic functionality and argument parsing
+- Stdin input handling
+- Model selection and validation
+- File-based prompt input
+- Print mode operation
+- Error handling
 
 ## Alternatives
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "openai": "^4.50.0"
       },
       "bin": {
+        "x": "index.js",
+        "yolo": "index.js",
         "yolox": "index.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "repository": "https://github.com/zeke/yolox",
   "scripts": {
-    "test": "standard",
+    "test": "node test.js && standard",
+    "test:unit": "node test.js",
+    "test:lint": "standard",
     "lint": "standard --fix"
   },
   "keywords": [

--- a/test.js
+++ b/test.js
@@ -1,20 +1,144 @@
-import OpenAI from 'openai'
+#!/usr/bin/env node
 
-const openai = new OpenAI({
-  apiKey: process.env.REPLICATE_API_TOKEN,
-  baseURL: 'https://openai-proxy.replicate.com/v1'
-})
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { spawn } from 'node:child_process'
+import { writeFile, unlink } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 
-const completions = await openai.chat.completions.create({
-  model: 'meta/meta-llama-3-70b-instruct',
-  messages: [
-    {
-      role: 'user',
-      content: 'Write a haiku about camelids'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const yoloxPath = join(__dirname, 'index.js')
+
+// Helper function to run yolox with various inputs
+async function runYolox (args = [], stdin = null, env = {}, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [yoloxPath, ...args], {
+      env: { ...process.env, ...env },
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+
+    let stdout = ''
+    let stderr = ''
+    let timedOut = false
+
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+      resolve({ code: -1, stdout, stderr, timedOut: true })
+    }, timeout)
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString()
+    })
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+
+    child.on('close', (code) => {
+      clearTimeout(timer)
+      if (!timedOut) {
+        resolve({ code, stdout, stderr, timedOut: false })
+      }
+    })
+
+    child.on('error', (err) => {
+      clearTimeout(timer)
+      if (!timedOut) {
+        reject(err)
+      }
+    })
+
+    if (stdin) {
+      child.stdin.write(stdin)
+      child.stdin.end()
+    } else {
+      child.stdin.end()
     }
-  ],
-  maxTokens: 64
-})
-for await (const part of completions) {
-  process.stdout.write(part.choices[0]?.delta?.content || '')
+  })
 }
+
+test('yolox shows usage when no command provided', async () => {
+  const result = await runYolox([])
+  assert.strictEqual(result.code, 0)
+  assert(result.stdout.includes('Usage: yolox <english-command>'))
+  assert(result.stdout.includes('Example with stdin:'))
+})
+
+test('yolox shows error for unsupported model', async () => {
+  const result = await runYolox(['--model=invalid', 'list files'])
+  assert.strictEqual(result.code, 0)
+  assert(result.stderr.includes("Error: Model 'invalid' is not supported"))
+  assert(result.stdout.includes('Available models are:'))
+})
+
+test('yolox handles file input for prompts', async () => {
+  const testPrompt = 'list all files in current directory'
+  const tempFile = 'test-prompt.txt'
+
+  try {
+    await writeFile(tempFile, testPrompt)
+    // This will fail due to missing API key, but should not error on file reading
+    const result = await runYolox([tempFile, '--print'])
+
+    // The process will exit with code 1 due to API error, but shouldn't have file reading errors
+    assert(!result.stderr.includes('Error reading file'))
+  } finally {
+    await unlink(tempFile).catch(() => {}) // Clean up
+  }
+})
+
+test('yolox accepts stdin input without crashing', async () => {
+  const stdinData = '{"name": "test", "value": 42}'
+  const result = await runYolox(['use jq to get the name field', '--print'], stdinData)
+
+  // Should not have stdin reading errors, even if API call fails
+  assert(!result.stderr.includes('Error reading from stdin'))
+})
+
+test('yolox supports model aliases without hanging', async () => {
+  // Test just one model to avoid hanging on API calls
+  const result = await runYolox(['--model=gpt-4o', 'echo hello'], null, {}, 3000)
+
+  // Should not error on model selection, might timeout on API call
+  assert(!result.stderr.includes('is not supported'))
+  // If it times out, that's expected without valid API keys
+  if (result.timedOut) {
+    console.log('  ℹ Test timed out as expected (no valid API key)')
+  }
+})
+
+test('yolox handles empty stdin gracefully', async () => {
+  const result = await runYolox(['list files'], '', {}, 3000)
+
+  // Should not error on empty stdin, might timeout on API call
+  assert(!result.stderr.includes('Error reading from stdin'))
+  if (result.timedOut) {
+    console.log('  ℹ Test timed out as expected (no valid API key)')
+  }
+})
+
+test('yolox includes proper usage examples', async () => {
+  const result = await runYolox([])
+
+  assert(result.stdout.includes('Usage: yolox <english-command>'))
+  assert(result.stdout.includes('Example:'))
+  assert(result.stdout.includes('Example with stdin:'))
+})
+
+test('yolox validates model names correctly', async () => {
+  const invalidModel = 'nonexistent-model'
+
+  // Test invalid model - this should exit quickly
+  const invalidResult = await runYolox(['--model=' + invalidModel, 'test'])
+  assert(invalidResult.stderr.includes('is not supported'))
+  assert(invalidResult.stdout.includes('Available models are:'))
+
+  // Test one valid model briefly
+  const result = await runYolox(['--model=gpt-4o', 'test'], null, {}, 2000)
+  assert(!result.stderr.includes('is not supported'))
+})
+
+console.log('Running yolox tests...')


### PR DESCRIPTION
- Add ability to pipe data to yolox (e.g., echo 'data' | yolox 'process this')
- Include piped data in AI model context for better command generation
- Add comprehensive test suite covering stdin, file input, and model validation
- Update documentation with stdin examples and usage patterns
- Add timeout handling to prevent hanging tests
- Update package.json with separate test commands
- Maintain backward compatibility with existing functionality

Examples:
- echo '{"foo": 1}' | yolox 'use jq to get keys'
- ps aux | yolox 'find processes using >50% CPU'
- curl api.com/data | yolox 'extract field with jq'